### PR TITLE
change twitter handles into links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ These are guest names I gathered in the fall that I plan to reach out to. If you
 Copy the snippet below, add your details and submit a PR!
 
 ```
-| Full Name | [social-media-handle](url-to-social-media-profile)* | Previous Career | ❌ | ❌ |
+| Full Name | [social-media-handle](url-to-social-media-profile) | Previous Career | ❌ | ❌ |
 ```
-*if you prefer not to share your contact info publicly you can email me directly at [secondcareerdevs@gmail.com](mailto:secondcareerdevs@gmail.com)
+If you prefer not to share your contact info publicly you can email me directly at [secondcareerdevs@gmail.com](mailto:secondcareerdevs@gmail.com).
 
 ## The List
 

--- a/README.md
+++ b/README.md
@@ -7,55 +7,56 @@ These are guest names I gathered in the fall that I plan to reach out to. If you
 Copy the snippet below, add your details and submit a PR!
 
 ```
-| Full Name | @twitterHandle | Previous Career | ❌ | ❌ |
+| Full Name | [social-media-handle](url-to-social-media-profile)* | Previous Career | ❌ | ❌ |
 ```
+*if you prefer not to share your contact info publicly you can email me directly at [secondcareerdevs@gmail.com](mailto:secondcareerdevs@gmail.com)
 
 ## The List
 
 | Name | Contact | Info | Scheduled? | Recorded? |
 |---|---|---|---|---|
-| Ashly LaMarr | @SurlyMae | Accountant | ✅ | ❌ |
-| Kelly Furness | @knfurness | Teacher | ❌ | ❌ |
-| Emily Freeman | @editingemily | Writer | ❌ | ❌ |
-| CodeRabbi | @coderabbi | Marketer and Rabbi | ❌ | ❌ |
-| Paul McBride | @ThePaulMcBride | Military | ✅ | ✅ |
-| Caitlyn Tetmeyer | @CaitlynTetmeyer | Peace Corps | ❌ | ❌ |
-| | @thestephwells | | ❌ | ❌ |
-| | @_lbaillie | Comic Artist | ❌ | ❌ |
-| | @kttravers | Art | ❌ | ❌ |
-| | @vaidehijoshi | Writer | ❌ | ❌ |
-| | @saronyitbarek | Writer | ❌ | ❌ |
-| Sal Hernandez | @clickclickonsal | Mechanic | ❌ | ❌ |
-| Sonia Gupta | @soniagupta504 | | ✅ | ✅ |
-| Johnny Grubb | @JohnnyGrubb | Musician | ❌ | ❌ |
-| David Kaye | @dfkaye | Outreach Ministry | ❌ | ❌ |
-| Oliver Turner | @oliverturner | Law | ❌ | ❌ |
-| JR Frazier | @jr_frazier1 | | ❌ | ❌ |
-| Aimee Knight | @Aimee_Knight | Figure Skater | ❌ | ❌ |
-| Ken Wheeler | @ken_wheeler | What hasn't this guy done? | ❌ | ❌ |
-| Jessica Grist | @thehackstress | Dancer, Costumer, Teacher | ❌ | ❌ |
-| Matt Rasband | @mattrasband | Financial Advisor | ❌ | ❌ |
-| Aaron Trank | @AaronTrank | Christian Minister | ❌ | ❌ |
+| Ashly LaMarr | [@SurlyMae](https://www.twitter.com/SurlyMae) | Accountant | ✅ | ❌ |
+| Kelly Furness | [@knfurness](https://www.twitter.com/knfurness) | Teacher | ❌ | ❌ |
+| Emily Freeman | [@editingemily](https://www.twitter.com/editingemily) | Writer | ❌ | ❌ |
+| CodeRabbi | [@coderabbi](https://www.twitter.com/coderabbi) | Marketer and Rabbi | ❌ | ❌ |
+| Paul McBride | [@ThePaulMcBride](https://www.twitter.com/ThePaulMcBride) | Military | ✅ | ✅ |
+| Caitlyn Tetmeyer | [@CaitlynTetmeyer](https://www.twitter.com/CaitlynTetmeyer) | Peace Corps | ❌ | ❌ |
+| | [@thestephwells](https://www.twitter.com/thestephwells) | | ❌ | ❌ |
+| | [@_lbaillie](https://www.twitter.com/_lbaillie) | Comic Artist | ❌ | ❌ |
+| | [@kttravers](https://www.twitter.com/kttravers) | Art | ❌ | ❌ |
+| | [@vaidehijoshi](https://www.twitter.com/vaidehijoshi) | Writer | ❌ | ❌ |
+| | [@saronyitbarek](https://www.twitter.com/saronyitbarek) | Writer | ❌ | ❌ |
+| Sal Hernandez | [@clickclickonsal](https://www.twitter.com/clickclickonsal) | Mechanic | ❌ | ❌ |
+| Sonia Gupta | [@soniagupta504](https://www.twitter.com/soniagupta504) | | ✅ | ✅ |
+| Johnny Grubb | [@JohnnyGrubb](https://www.twitter.com/JohnnyGrubb) | Musician | ❌ | ❌ |
+| David Kaye | [@dfkaye](https://www.twitter.com/dfkaye) | Outreach Ministry | ❌ | ❌ |
+| Oliver Turner | [@oliverturner](https://www.twitter.com/oliverturner) | Law | ❌ | ❌ |
+| JR Frazier | [@jr_frazier1](https://www.twitter.com/jr_frazier1) | | ❌ | ❌ |
+| Aimee Knight | [@Aimee_Knight](https://www.twitter.com/Aimee_Knight) | Figure Skater | ❌ | ❌ |
+| Ken Wheeler | [@ken_wheeler](https://www.twitter.com/ken_wheeler) | What hasn't this guy done? | ❌ | ❌ |
+| Jessica Grist | [@thehackstress](https://www.twitter.com/thehackstress) | Dancer, Costumer, Teacher | ❌ | ❌ |
+| Matt Rasband | [@mattrasband](https://www.twitter.com/mattrasband) | Financial Advisor | ❌ | ❌ |
+| Aaron Trank | [@AaronTrank](https://www.twitter.com/AaronTrank) | Christian Minister | ❌ | ❌ |
 | Priyanka Shah | email in DM from Suhas | Scientist doing Alzheimer's Research | ❌ | ❌ |
-| Niko | @codeswitched | | ❌ | ❌ |
-| Whitney Williams | @whitneyhacks | Fine Arts | ❌ | ❌ |
-| Kye Hohenberger | @tkh44 | Construction | ❌ | ❌ |
-| Sarah Drasner | @sarah_edo | Teacher | ❌ | ❌ |
-| Chris DeMars | @saltnburnem | Truck Driver | ❌ | ❌ |
-| Shane Barringer   | @shanebarringer  | B2B Sales  | ❌ | ❌ |
-| Ryan Florence | @ryanflorence | Sales | ❌ | ❌ |
-| Claire Niederberger | @clairenied | Exhibit/Environmental Design | ✅ | ✅ |
-| Marty Himmel | @MartyHimmel | Dental Technician | ❌ | ❌ |
-| Tracy Lee | @ladyleet | CEO of Food Startup | ❌ | ❌ |
-| Seán Stickle | @seanstickle | VP & Chief Strategy Officer at the Physician Assistant Education Association | ❌ | ❌ |
-| Bobby Johnson | @notmyself | Developer Advocate @ Auth0 | ✅ | ✅ |
-| @swyx | @swyx | Options Trader/ Hedge Fund Analyst => Software Eng at Two Sigma | ❌ | ❌ |
-| Andrew Cook | @codingwcookie | EMT | ✅ | ✅ |
-| Telmo Goncalves | @telmo | Warehouse Worker | ❌ | ❌ |
-| Christina Gorton| @coffeecraftcode | nanny, housekeeper at nursing home, stay at home mom  | ❌ | ❌ |
-| Madison Kanna | @MadisonKanna | Fashion Model | ✅ | ✅ |
-| Joel Griffith | @griffith_joel | Jazz Trumpet Player | ❌ | ❌ |
-| Kat Reinhart | @katreinhart | Neuroscientist | ❌ | ❌ |
-| Rich Finelli | @rich_ard_f | Software Trainer/Tech Support | ❌ | ❌ |
-| Yechiel Kalmenson | @yechielk | Rabbi/Teacher/Tech Support | ❌ | ❌ |
-| Ross Kaffenberger | @rossta | Science Teacher | ❌ | ❌ |
+| Niko | [@codeswitched](https://www.twitter.com/codeswitched) | | ❌ | ❌ |
+| Whitney Williams | [@whitneyhacks](https://www.twitter.com/whitneyhacks) | Fine Arts | ❌ | ❌ |
+| Kye Hohenberger | [@tkh44](https://www.twitter.com/tkh44) | Construction | ❌ | ❌ |
+| Sarah Drasner | [@sarah_edo](https://www.twitter.com/sarah_edo) | Teacher | ❌ | ❌ |
+| Chris DeMars | [@saltnburnem](https://www.twitter.com/saltnburnem) | Truck Driver | ❌ | ❌ |
+| Shane Barringer | [@shanebarringer](https://www.twitter.com/shanebarringer)  | B2B Sales  | ❌ | ❌ |
+| Ryan Florence | [@ryanflorence](https://www.twitter.com/ryanflorence) | Sales | ❌ | ❌ |
+| Claire Niederberger | [@clairenied](https://www.twitter.com/clairenied) | Exhibit/Environmental Design | ✅ | ✅ |
+| Marty Himmel | [@MartyHimmel](https://www.twitter.com/MartyHimmel) | Dental Technician | ❌ | ❌ |
+| Tracy Lee | [@ladyleet](https://www.twitter.com/ladyleet) | CEO of Food Startup | ❌ | ❌ |
+| Seán Stickle | [@seanstickle](https://www.twitter.com/seanstickle) | VP & Chief Strategy Officer at the Physician Assistant Education Association | ❌ | ❌ |
+| Bobby Johnson | [@notmyself](https://www.twitter.com/notmyself) | Developer Advocate @ Auth0 | ✅ | ✅ |
+| @swyx | [@swyx](https://www.twitter.com/swyx) | Options Trader/ Hedge Fund Analyst => Software Eng at Two Sigma | ❌ | ❌ |
+| Andrew Cook | [@codingwcookie](https://www.twitter.com/codingwcookie) | EMT | ✅ | ✅ |
+| Telmo Goncalves | [@telmo](https://www.twitter.com/telmo) | Warehouse Worker | ❌ | ❌ |
+| Christina Gorton| [@coffeecraftcode](https://www.twitter.com/coffeecraftcode) | nanny, housekeeper at nursing home, stay at home mom  | ❌ | ❌ |
+| Madison Kanna | [@MadisonKanna](https://www.twitter.com/MadisonKanna) | Fashion Model | ✅ | ✅ |
+| Joel Griffith | [@griffith_joel](https://www.twitter.com/griffith_joel) | Jazz Trumpet Player | ❌ | ❌ |
+| Kat Reinhart | [@katreinhart](https://www.twitter.com/katreinhart) | Neuroscientist | ❌ | ❌ |
+| Rich Finelli | [@rich_ard_f](https://www.twitter.com/rich_ard_f) | Software Trainer/Tech Support | ❌ | ❌ |
+| Yechiel Kalmenson | [@yechielk](https://www.twitter.com/yechielk) | Rabbi/Teacher/Tech Support | ❌ | ❌ |
+| Ross Kaffenberger | [@rossta](https://www.twitter.com/rossta) | Science Teacher | ❌ | ❌ |


### PR DESCRIPTION
I changed all the Twitter handles into links to the Twitter profiles, I feel like that would be helpful to people like me who want to follow other career changers on Twitter :)

I also changed the wording in the instructions for people who might prefer another social medium other than Twitter or who might not be comfortable sharing their contact info in public.